### PR TITLE
Fix TODO: Handle unhandled errors in TaskGroup to prevent build failure

### DIFF
--- a/src/backend/base/langflow/graph/vertex/base.py
+++ b/src/backend/base/langflow/graph/vertex/base.py
@@ -396,6 +396,7 @@ class Vertex:
             custom_params = initialize.loading.get_params(self.params)
 
         await self._build_results(
+// TODO: Handle unhandled errors in TaskGroup to prevent build failure [Context: Bug report #1234] [Next Steps: Implement error handling logic to properly manage TaskGroup exceptions]
             custom_component=custom_component,
             custom_params=custom_params,
             fallback_to_env_vars=fallback_to_env_vars,


### PR DESCRIPTION
### Context
Bug report #1234

### Description
This PR inserts a TODO comment to address the following issue:
**Handle unhandled errors in TaskGroup to prevent build failure**

### Next Steps
Implement error handling logic to properly manage TaskGroup exceptions

### Reasoning
The error occurs during the build process in the _build_results function, indicating that handling errors in TaskGroup here would be appropriate.

---
*This change was automatically generated based on RAG output.*