### PR TITLE
Fix TODO: Handle unhandled errors in TaskGroup when updating tool list

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1268,6 +1268,7 @@ class Component(CustomComponent):
         return Input(**kwargs)
 
     async def to_toolkit(self) -> list[Tool]:
+// TODO: Enhance error reporting for failed tool list updates [Context: Bug report for MCP integration failure after adding Google Sheets server] [Next Steps: Implement detailed error logging and reporting for tool list update failures]
         """Convert component to a list of tools.
 
         This is a template method that defines the skeleton of the toolkit creation

--- a/src/backend/base/langflow/graph/vertex/base.py
+++ b/src/backend/base/langflow/graph/vertex/base.py
@@ -396,6 +396,7 @@ class Vertex:
             custom_params = initialize.loading.get_params(self.params)
 
         await self._build_results(
+// TODO: Handle unhandled errors in TaskGroup when updating tool list [Context: Bug report for MCP integration failure after adding Google Sheets server] [Next Steps: Implement error handling logic to properly manage TaskGroup exceptions]
             custom_component=custom_component,
             custom_params=custom_params,
             fallback_to_env_vars=fallback_to_env_vars,

--- a/src/backend/base/langflow/interface/initialize/loading.py
+++ b/src/backend/base/langflow/interface/initialize/loading.py
@@ -51,6 +51,7 @@ def instantiate_class(
 
 
 async def get_instance_results(
+// TODO: Improve error handling for MCP tool list updates [Context: Bug report for MCP integration failure after adding Google Sheets server] [Next Steps: Enhance error handling mechanism to address TaskGroup exceptions]
     custom_component,
     custom_params: dict,
     vertex: Vertex,


### PR DESCRIPTION
### Context
Bug report for MCP integration failure after adding Google Sheets server

### Description
This PR inserts a TODO comment to address the following issue:
**Handle unhandled errors in TaskGroup when updating tool list**

### Next Steps
Implement error handling logic to properly manage TaskGroup exceptions

### Reasoning
The error occurs during the build process, indicating a need to handle errors in TaskGroup

---
*This change was automatically generated based on RAG output.*