### PR TITLE
Fix TODO: Check for Credential type variables when getting a variable

### DIFF
--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -88,6 +88,7 @@ class DatabaseVariableService(VariableService, Service):
         for variable in variables:
             value = None
             if variable.type == GENERIC_TYPE:
+// TODO: Check for Credential type variables when getting a variable [Context: Bug report] [Next Steps: Update the condition to check for both GENERIC_TYPE and CREDENTIAL_TYPE]
                 try:
                     value = auth_utils.decrypt_api_key(variable.value, settings_service=self.settings_service)
                 except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
### Context
Bug report

### Description
This PR inserts a TODO comment to address the following issue:
**Check for Credential type variables when getting a variable**

### Next Steps
Update the condition to check for both GENERIC_TYPE and CREDENTIAL_TYPE

### Reasoning
The change should be made in the service.py file where the variable type is checked. By updating the condition to check for both GENERIC_TYPE and CREDENTIAL_TYPE, the issue with assigning null values to variables when getting credential variables can be resolved.

---
*This change was automatically generated based on RAG output.*