### PR TITLE
Fix TODO: Update test assertions to expect messages in reverse chronological order

### DIFF
--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -59,6 +59,7 @@ def test_get_messages():
     assert len(messages) == 2
     assert messages[0].text == "Test message 1"
     assert messages[1].text == "Test message 2"
+// TODO: Update test assertions to expect messages in reverse chronological order [Context: Bug Report: Incorrect Test Assertions in Message Order] [Next Steps: Update the test assertions to expect the newest message first]
 
 
 @pytest.mark.usefixtures("client")


### PR DESCRIPTION
### Context
Bug Report: Incorrect Test Assertions in Message Order

### Description
This PR inserts a TODO comment to address the following issue:
**Update test assertions to expect messages in reverse chronological order**

### Next Steps
Update the test assertions to expect the newest message first

### Reasoning
The test assertions in this file need to be updated to align with the default behavior of message retrieval in reverse chronological order.

---
*This change was automatically generated based on RAG output.*