### PR TITLE
Fix TODO: Update test assertions to expect messages in reverse chronological order

### DIFF
--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -57,6 +57,7 @@ def test_get_messages():
     )
     messages = get_messages(sender="User", session_id="session_id2", limit=2)
     assert len(messages) == 2
+// TODO: Update test assertions to expect messages in reverse chronological order [Context: Bug Report: Incorrect Test Assertions in Message Order] [Next Steps: Update the test assertions to expect the newest message first and the older message second.]
     assert messages[0].text == "Test message 1"
     assert messages[1].text == "Test message 2"
 


### PR DESCRIPTION
### Context
Bug Report: Incorrect Test Assertions in Message Order

### Description
This PR inserts a TODO comment to address the following issue:
**Update test assertions to expect messages in reverse chronological order**

### Next Steps
Update the test assertions to expect the newest message first and the older message second.

### Reasoning
The issue is related to the test assertions in the test_aget_messages function. Placing the TODO after the assertion check for the length of messages ensures that the new expectations are set correctly.

---
*This change was automatically generated based on RAG output.*