### PR TITLE
Fix TODO: Ensure custom components are loaded from category folders

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -1,3 +1,7 @@
+# TODO: Ensure custom components are loaded from category folders
+# [Context: Custom components are not appearing in the UI despite being correctly placed in the docker volume. The issue is related to the directory structure expected by Langflow.]
+# [Next Steps: Verify and modify the component loading logic to ensure it recursively searches for components within category folders under the specified LANGFLOW_COMPONENTS_PATH.]
+
 from __future__ import annotations
 
 import uuid


### PR DESCRIPTION
### Context
Custom components are not appearing in the UI despite being correctly placed in the docker volume. The issue is related to the directory structure expected by Langflow.

### Description
Ensure custom components are loaded from category folders

### Next Steps
Verify and modify the component loading logic to ensure it recursively searches for components within category folders under the specified LANGFLOW_COMPONENTS_PATH.

### Reasoning
The file is part of the core functionality where custom components are defined and managed. Adjusting the loading mechanism here will directly address the issue of components not appearing in the UI, as this is where components are initially processed and integrated into the system.

---
*Generated automatically from Langflow.*